### PR TITLE
Move redundant assertion out of loop

### DIFF
--- a/solutions/code/tutorialquestions/question4c70/Lottery.java
+++ b/solutions/code/tutorialquestions/question4c70/Lottery.java
@@ -10,10 +10,10 @@ public class Lottery {
 
   private static boolean numberAlreadyChosen(int[] numbers,
       int numChosenSoFar, int candidate) {
+    
+    assert numChosenSoFar < numbers.length;
 
     for (int i = 0; i < numChosenSoFar; i++) {
-
-      assert numChosenSoFar < numbers.length;
 
       if (numbers[i] == candidate) {
 


### PR DESCRIPTION
Just something small I found: as far as I can tell, it's redundant to assert that `numChosenSoFar < numbers.length` more than once, since neither value is changed within the loop. I think it's better to move the check outside the loop so that it's only executed once.